### PR TITLE
Removed pmd and now mvn site works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,11 +107,6 @@
   <reporting>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.13.0</version>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jdepend-maven-plugin</artifactId>
         <version>2.0</version>


### PR DESCRIPTION
A report is generated by JDepend when mvn site is ran. Can be found in target/site

EC, EW