### PR TITLE
updated descriptorref. couldn't package with "runnable" as descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
             </manifest>
           </archive>
           <descriptorRefs>
-            <descriptorRef>runnable</descriptorRef>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
         </configuration>
         <executions>


### PR DESCRIPTION
Small fix for maven

EC